### PR TITLE
(fix) typo

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,7 +26,7 @@
     {{ if .Params.highlight }}
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/default.min.css">
     {{ end }}
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
     <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
add slash to style.css link.
ex:
if baseURL = `https://vazh.github.io`,  
without slash it produce :
`http://vazh.github.iocss/style.css`